### PR TITLE
feat: Add opta mode

### DIFF
--- a/include/robotnik_charge/robotnik_charge.hpp
+++ b/include/robotnik_charge/robotnik_charge.hpp
@@ -135,7 +135,7 @@ private:
   void send_move_backwards();
   void send_rotation();
   void send_move(Pose pose);
-  bool set_charge_relay(bool activate);
+  bool activate_charge(bool activate);
   bool set_dock_laser_mode(bool activate);
   void retry();
   void charge_abort();
@@ -158,6 +158,7 @@ private:
   rclcpp::Subscription<DockingStatus>::SharedPtr docking_status_subscription_;
 
   rclcpp::Client<SetBool>::SharedPtr set_charger_relay_;
+  rclcpp::Client<SetBool>::SharedPtr set_charger_enable_;
   rclcpp::Client<SetString>::SharedPtr set_laser_mode_;
 
   rclcpp_action::Client<Dock>::SharedPtr dock_action_client_;

--- a/src/atomic_actions.cpp
+++ b/src/atomic_actions.cpp
@@ -41,10 +41,10 @@ bool RobotnikCharge::set_dock_laser_mode(bool activate)
   return success;
 }
 
-bool RobotnikCharge::set_charge_relay(bool activate)
+bool RobotnikCharge::activate_charge(bool activate)
 {
   if (docking_operation_mode_ != DockingStatus::_status_type::MODE_MANUAL_SW
-      && docking_operation_mode_ != DockingStatus::_status_type::MODE_OPTA)
+      && docking_operation_mode_ != DockingStatus::_status_type::MODE_AUTO_HW)
   {
     RCLCPP_WARN(this->get_logger(), "Docking mode is %s, skipping set charge relay step", docking_operation_mode_.c_str());
     return true;
@@ -52,8 +52,17 @@ bool RobotnikCharge::set_charge_relay(bool activate)
 
   auto request = std::make_shared<SetBool::Request>();
   static auto response = std::make_shared<SetBool::Response>();
-  request->data = activate;
-  service_call(set_charger_relay_, request, response, service_callback_executed_);
+
+  if (docking_operation_mode_ == DockingStatus::_status_type::MODE_MANUAL_SW)
+  {
+    request->data = activate;
+    service_call(set_charger_relay_, request, response, service_callback_executed_);
+  }
+  else
+  {
+    request->data = activate;
+    service_call(set_charger_enable_, request, response, service_callback_executed_);
+  }
 
   if (!service_callback_executed_) // Callback not executed yet
   {

--- a/src/atomic_actions.cpp
+++ b/src/atomic_actions.cpp
@@ -43,7 +43,8 @@ bool RobotnikCharge::set_dock_laser_mode(bool activate)
 
 bool RobotnikCharge::set_charge_relay(bool activate)
 {
-  if (docking_operation_mode_ != DockingStatus::_status_type::MODE_MANUAL_SW)
+  if (docking_operation_mode_ != DockingStatus::_status_type::MODE_MANUAL_SW
+      && docking_operation_mode_ != DockingStatus::_status_type::MODE_OPTA)
   {
     RCLCPP_WARN(this->get_logger(), "Docking mode is %s, skipping set charge relay step", docking_operation_mode_.c_str());
     return true;

--- a/src/robotnik_charge.cpp
+++ b/src/robotnik_charge.cpp
@@ -47,6 +47,18 @@ RobotnikCharge::RobotnikCharge()
     RCLCPP_INFO(this->get_logger(), "Service \"%s\" not available, waiting again...", set_charger_relay_->get_service_name());
   }
 
+  set_charger_enable_ = create_client<SetBool>("~/set_charger_enable");
+  while (!set_charger_enable_->wait_for_service(1s))
+  {
+    if (!rclcpp::ok())
+    {
+      RCLCPP_ERROR(this->get_logger(), "Interrupted while waiting for the service \"%s\". Exiting.",
+                   set_charger_enable_->get_service_name());
+      return;
+    }
+    RCLCPP_INFO(this->get_logger(), "Service \"%s\" not available, waiting again...", set_charger_enable_->get_service_name());
+  }
+
   // Service client to set laser mode
   if (params_.has_safety_lasers)
   {
@@ -347,7 +359,7 @@ void RobotnikCharge::handle_charge_steps(std::shared_ptr<Timer>& timer)
       break;
 
     case RobotnikChargeState::ActivateRelay:
-      if (set_charge_relay(true))
+      if (activate_charge(true))
       {
         switch_to_state(RobotnikChargeState::WaitCharging, timer);
         timer->change_duration(params_.timeout_charging_detection);
@@ -374,7 +386,7 @@ void RobotnikCharge::handle_charge_steps(std::shared_ptr<Timer>& timer)
       break;
 
     case RobotnikChargeState::DeactivateRelay:
-      if (set_charge_relay(false))
+      if (activate_charge(false))
       {
         switch_to_state(RobotnikChargeState::MovingBackwards, timer);
       }
@@ -569,7 +581,7 @@ void RobotnikCharge::handle_uncharge_steps(std::shared_ptr<Timer>& timer)
   switch (charge_manager_state_)
   {
     case RobotnikChargeState::DeactivateRelay:
-      if (set_charge_relay(false))
+      if (activate_charge(false))
       {
         switch_to_state(RobotnikChargeState::DeactivatingLasers, timer);
       }
@@ -649,6 +661,7 @@ void RobotnikCharge::handle_timeout_for_steps(std::shared_ptr<Timer>& timer)
   {
     case RobotnikChargeState::DeactivateRelay:
       remove_pending_requests(set_charger_relay_);
+      remove_pending_requests(set_charger_enable_);
       switch_to_state(RobotnikChargeState::Aborted, timer);
       break;
 
@@ -668,6 +681,7 @@ void RobotnikCharge::handle_timeout_for_steps(std::shared_ptr<Timer>& timer)
 
     case RobotnikChargeState::ActivateRelay:
       remove_pending_requests(set_charger_relay_);
+      remove_pending_requests(set_charger_enable_);
       switch_to_state(RobotnikChargeState::Retry, timer);
       break;
 


### PR DESCRIPTION
This pull request updates the charging activation logic in the `RobotnikCharge` node to support both manual and automatic docking modes via two distinct service clients. The main change is a refactor of the relay activation method to select the appropriate service depending on the docking mode, along with the introduction of a new service client for automatic mode. Several method and variable names have been updated for clarity, and related state machine transitions have been adjusted accordingly.

### Charging Activation Logic Improvements

* Refactored the `set_charge_relay` method to `activate_charge`, which now selects between `set_charger_relay_` (manual mode) and the new `set_charger_enable_` (automatic mode) service clients based on the current docking operation mode.
* Added a new `set_charger_enable_` service client, initialized in the constructor, to support automatic hardware docking mode. [[1]](diffhunk://#diff-d4fdf447166f08578365c4abef909b95f88ce56648becbecf24467fdf60e2ca5R50-R61) [[2]](diffhunk://#diff-fbbd2f60d4fecc0a499159b7cf41503602f08af6020bb86388cb41c5b77c1e89R161)

### State Machine and Timeout Handling

* Updated all state machine transitions and timeout handlers to use the new `activate_charge` method instead of the old `set_charge_relay`, ensuring correct behavior in both manual and automatic modes. [[1]](diffhunk://#diff-d4fdf447166f08578365c4abef909b95f88ce56648becbecf24467fdf60e2ca5L350-R362) [[2]](diffhunk://#diff-d4fdf447166f08578365c4abef909b95f88ce56648becbecf24467fdf60e2ca5L377-R389) [[3]](diffhunk://#diff-d4fdf447166f08578365c4abef909b95f88ce56648becbecf24467fdf60e2ca5L572-R584)
* Modified timeout handlers to remove pending requests from both `set_charger_relay_` and `set_charger_enable_` clients. [[1]](diffhunk://#diff-d4fdf447166f08578365c4abef909b95f88ce56648becbecf24467fdf60e2ca5R664) [[2]](diffhunk://#diff-d4fdf447166f08578365c4abef909b95f88ce56648becbecf24467fdf60e2ca5R684)

### API Consistency

* Updated the method name in the class declaration from `set_charge_relay` to `activate_charge` for improved clarity and consistency.